### PR TITLE
Update Deploy to Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Read more at [fusionauth.io](https://fusionauth.io) and the [docs](https://fusio
 Deploy to Fusion Auth Server with Heroku Postgres (free).
 
 [![Deploy to
-Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/pankyka/fusion-auth-heroku)
+Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/pankyka/fusionauth-heroku)


### PR DESCRIPTION
The template path for the Deploy to Heroku button is not pointing to this repo; updated the URL to properly allow launching an instance on Heroku.